### PR TITLE
Fixed "Deploy to Heroku"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ Open your browser and visit [localhost:8080](http://localhost:8080/) et voilá!
 
 To get your own GraphQL Starwars example running on Heroku, click the button below:
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/graphql-python/swapi-graphene)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 Fill out the form, and you should be cooking with gas in a few seconds.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,6 @@
+{
+  "name": "SWAPI Graphene",
+  "description": "GraphQL Starwars Api using Graphene and Django",
+  "repository": "https://github.com/graphql-python/swapi-graphene",
+  "keywords": ["SWAPI", "Graphene", "GraphQL"]
+}

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,5 +1,5 @@
 Django==1.9.6
-graphene[django]==0.9.0
+graphene[django]==0.10.0
 django-graphiql==0.4.4
 django-filter==0.12.0
 django-environ==0.4.0

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -3,3 +3,4 @@ graphene[django]==0.10.0
 django-graphiql==0.4.4
 django-filter==0.12.0
 django-environ==0.4.0
+psycopg2==2.6.1

--- a/starwars/schema.py
+++ b/starwars/schema.py
@@ -157,7 +157,7 @@ class Query(graphene.ObjectType):
     character = relay.NodeField(Person)
     vehicle = relay.NodeField(Vehicle)
     planet = relay.NodeField(Planet)
-    startship = relay.NodeField(Starship)
+    starship = relay.NodeField(Starship)
     hero = relay.NodeField(Hero)
     node = relay.NodeField()
     viewer = graphene.Field('self')

--- a/starwars/schema.py
+++ b/starwars/schema.py
@@ -6,13 +6,13 @@ import graphene
 from graphene import resolve_only_args, relay
 from graphene.contrib.django import DjangoNode, DjangoConnection
 from graphene.contrib.django.filter import DjangoFilterConnectionField
-from graphene.contrib.django.debug import DjangoDebugPlugin
+from graphene.contrib.django.debug import DjangoDebugMiddleware, DjangoDebug
 from graphql_relay.node.node import from_global_id
 
 import models
 
 
-schema = graphene.Schema(name='Starwars Relay Schema', plugins=[DjangoDebugPlugin()])
+schema = graphene.Schema(name='Starwars Relay Schema', middlewares=[DjangoDebugMiddleware()])
 
 
 class Connection(DjangoConnection):
@@ -161,6 +161,8 @@ class Query(graphene.ObjectType):
     hero = relay.NodeField(Hero)
     node = relay.NodeField()
     viewer = graphene.Field('self')
+
+    debug = graphene.Field(DjangoDebug, name='__debug')
 
     def resolve_viewer(self, *args, **kwargs):
         return self

--- a/starwars/schema.py
+++ b/starwars/schema.py
@@ -167,6 +167,7 @@ class Query(graphene.ObjectType):
     def resolve_viewer(self, *args, **kwargs):
         return self
 
+
 class CreateHero(relay.ClientIDMutation):
 
     # Required input from mutation query

--- a/starwars/schema.py
+++ b/starwars/schema.py
@@ -167,18 +167,40 @@ class Query(graphene.ObjectType):
     def resolve_viewer(self, *args, **kwargs):
         return self
 
+"""
+Sample mutation:
+mutation myFirstMutation {
+    createHero($input: CreateHeroInput!) {
+        hero {
+            name
+        },
+        ok
+    }
+}
 
+Parameters:
+{
+    "input": {
+        "clientMutationId": "<anything you want here>",
+        "name": "Finn",
+        "homeworld_id": 1
+    }
+}
+"""
 class CreateHero(relay.ClientIDMutation):
 
+    # Required input from mutation query
     class Input:
         name = graphene.String(required=True)
         homeworld_id = graphene.String(required=True)
 
+    # Payload to return after mutation
     hero = graphene.Field(Hero)
     ok = graphene.Boolean()
 
     @classmethod
     def mutate_and_get_payload(cls, input, info):
+        # Get data from mutation query
         name = input.get('name')
         homeworld_id = input.get('homeworld_id')
         assert homeworld_id, 'homeworld_id must be not null'
@@ -191,7 +213,8 @@ class CreateHero(relay.ClientIDMutation):
                 homeworld_id = resolved.id
             except:
                 raise Exception("Received wrong Planet id: {}".format(homeworld_id))
-
+                
+        # Creation of new database entry
         homeworld = Planet._meta.model.objects.get(id=homeworld_id)
         hero = Hero._meta.model(name=name, homeworld=homeworld)
         hero.save()

--- a/starwars/schema.py
+++ b/starwars/schema.py
@@ -167,26 +167,6 @@ class Query(graphene.ObjectType):
     def resolve_viewer(self, *args, **kwargs):
         return self
 
-"""
-Sample mutation:
-mutation myFirstMutation {
-    createHero($input: CreateHeroInput!) {
-        hero {
-            name
-        },
-        ok
-    }
-}
-
-Parameters:
-{
-    "input": {
-        "clientMutationId": "<anything you want here>",
-        "name": "Finn",
-        "homeworld_id": 1
-    }
-}
-"""
 class CreateHero(relay.ClientIDMutation):
 
     # Required input from mutation query


### PR DESCRIPTION
Deploy to Heroku expects an `app.json` file in the root that I provided. Now the button works.
(I also removed the absolute template reference from the button so that this button installs
the cloned directory, not the one on graphql-python)

Note: I have no idea about those 5 other commits that are part of this pull request, they kind of appeared out of thin air. Mine is only _Create app.json so the 'Deploy to Heroku' works_. But you probably know that...
